### PR TITLE
Feat/background animation >> 백그라운드 애니메이션 SwiftUI 파일 추가 및 애니메이션 구현

### DIFF
--- a/Bingha/Bingha.xcodeproj/project.pbxproj
+++ b/Bingha/Bingha.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		5525498F2882B79400C0C75A /* Complete.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5525498E2882B79400C0C75A /* Complete.storyboard */; };
 		552549912882B7ED00C0C75A /* Measure.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 552549902882B7ED00C0C75A /* Measure.storyboard */; };
 		A3D8F657288FBD880083D033 /* MeasureBackgroundAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D8F656288FBD880083D033 /* MeasureBackgroundAnimation.swift */; };
+		A3D8F659288FC5490083D033 /* IcebergBackgroundAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D8F658288FC5490083D033 /* IcebergBackgroundAnimation.swift */; };
 		B54FF5A0288833F5004AB220 /* background.json in Resources */ = {isa = PBXBuildFile; fileRef = B54FF59F288833F5004AB220 /* background.json */; };
 		B5B91377288D553000F1161B /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = B5B91376288D553000F1161B /* Lottie */; };
 		B5EB63CB2887F26000A0B915 /* walker.json in Resources */ = {isa = PBXBuildFile; fileRef = B5EB63CA2887F26000A0B915 /* walker.json */; };
@@ -78,6 +79,7 @@
 		5525498E2882B79400C0C75A /* Complete.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Complete.storyboard; sourceTree = "<group>"; };
 		552549902882B7ED00C0C75A /* Measure.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Measure.storyboard; sourceTree = "<group>"; };
 		A3D8F656288FBD880083D033 /* MeasureBackgroundAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureBackgroundAnimation.swift; sourceTree = "<group>"; };
+		A3D8F658288FC5490083D033 /* IcebergBackgroundAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IcebergBackgroundAnimation.swift; sourceTree = "<group>"; };
 		B54FF59F288833F5004AB220 /* background.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = background.json; sourceTree = "<group>"; };
 		B5EB63CA2887F26000A0B915 /* walker.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = walker.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -214,6 +216,7 @@
 				5516E74C288129D20015D64A /* IcebergViewController.swift */,
 				39D8843E288680D3006067C8 /* Iceberg.storyboard */,
 				39E50CCB28870DC600173E25 /* CircularProgressBarView.swift */,
+				A3D8F658288FC5490083D033 /* IcebergBackgroundAnimation.swift */,
 			);
 			path = Iceberg;
 			sourceTree = "<group>";
@@ -352,6 +355,7 @@
 				0E8C8E5E2885428300A9ABDB /* DecreaseCarbonModel.swift in Sources */,
 				39D883DA28853C5F006067C8 /* ReducedCarbonCalculator.swift in Sources */,
 				5516E747288129B90015D64A /* CompleteViewController.swift in Sources */,
+				A3D8F659288FC5490083D033 /* IcebergBackgroundAnimation.swift in Sources */,
 				A3D8F657288FBD880083D033 /* MeasureBackgroundAnimation.swift in Sources */,
 				5516E73E2881291F0015D64A /* ModelNamingTest.swift in Sources */,
 			);

--- a/Bingha/Bingha.xcodeproj/project.pbxproj
+++ b/Bingha/Bingha.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		5516E74D288129D20015D64A /* IcebergViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5516E74C288129D20015D64A /* IcebergViewController.swift */; };
 		5525498F2882B79400C0C75A /* Complete.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 5525498E2882B79400C0C75A /* Complete.storyboard */; };
 		552549912882B7ED00C0C75A /* Measure.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 552549902882B7ED00C0C75A /* Measure.storyboard */; };
+		A3D8F657288FBD880083D033 /* MeasureBackgroundAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3D8F656288FBD880083D033 /* MeasureBackgroundAnimation.swift */; };
 		B54FF5A0288833F5004AB220 /* background.json in Resources */ = {isa = PBXBuildFile; fileRef = B54FF59F288833F5004AB220 /* background.json */; };
 		B5B91377288D553000F1161B /* Lottie in Frameworks */ = {isa = PBXBuildFile; productRef = B5B91376288D553000F1161B /* Lottie */; };
 		B5EB63CB2887F26000A0B915 /* walker.json in Resources */ = {isa = PBXBuildFile; fileRef = B5EB63CA2887F26000A0B915 /* walker.json */; };
@@ -76,6 +77,7 @@
 		5516E74C288129D20015D64A /* IcebergViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IcebergViewController.swift; sourceTree = "<group>"; };
 		5525498E2882B79400C0C75A /* Complete.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Complete.storyboard; sourceTree = "<group>"; };
 		552549902882B7ED00C0C75A /* Measure.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Measure.storyboard; sourceTree = "<group>"; };
+		A3D8F656288FBD880083D033 /* MeasureBackgroundAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasureBackgroundAnimation.swift; sourceTree = "<group>"; };
 		B54FF59F288833F5004AB220 /* background.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = background.json; sourceTree = "<group>"; };
 		B5EB63CA2887F26000A0B915 /* walker.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = walker.json; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -221,6 +223,7 @@
 			children = (
 				5516E748288129C00015D64A /* MeasureViewController.swift */,
 				552549902882B7ED00C0C75A /* Measure.storyboard */,
+				A3D8F656288FBD880083D033 /* MeasureBackgroundAnimation.swift */,
 			);
 			path = Measure;
 			sourceTree = "<group>";
@@ -349,6 +352,7 @@
 				0E8C8E5E2885428300A9ABDB /* DecreaseCarbonModel.swift in Sources */,
 				39D883DA28853C5F006067C8 /* ReducedCarbonCalculator.swift in Sources */,
 				5516E747288129B90015D64A /* CompleteViewController.swift in Sources */,
+				A3D8F657288FBD880083D033 /* MeasureBackgroundAnimation.swift in Sources */,
 				5516E73E2881291F0015D64A /* ModelNamingTest.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Bingha/Bingha/Views/Home/Measure/MeasureBackgroundAnimation.swift
+++ b/Bingha/Bingha/Views/Home/Measure/MeasureBackgroundAnimation.swift
@@ -1,0 +1,129 @@
+//
+//  MeasureBackgroundAnimation.swift
+//  Bingha
+//
+//  Created by HanGyeongjun on 2022/07/26.
+//
+
+import SwiftUI
+
+struct MeasureBackgroundAnimation: View {
+    
+    let universalSize = UIScreen.main.bounds
+    
+    @State private var isAnimated = false
+    var body: some View {
+        
+        ZStack {
+            getWave(interval: universalSize.width, amplitude: 125, baseline: -60 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 0.0, green: 0.6, blue: 1).opacity(0.1))
+                .offset(x: isAnimated ? -1*universalSize.width : 0)
+                .animation(
+                    Animation.linear(duration: 15.9)
+                    .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            getWave(interval: universalSize.width*1.2, amplitude: 70, baseline: -35 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 0.1, green: 0.6, blue: 1).opacity(0.1))
+                .offset(x: isAnimated ? -1*(universalSize.width*1.2) : 0)
+                .animation(
+                    Animation.linear(duration: 8.7)
+                    .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            getWave(interval: universalSize.width*1.5, amplitude: 50, baseline: -20 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 0.4, green: 0.6, blue: 1).opacity(0.1))
+                .offset(x: isAnimated ? -1*(universalSize.width*1.5) : 0)
+                .animation(
+                    Animation.linear(duration: 10.4)
+                    .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            //흰색 레이어
+            getWave(interval: universalSize.width*1, amplitude: 100, baseline: 45 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 1, green: 1, blue: 1).opacity(0.5))
+                .offset(x: isAnimated ? -1*(universalSize.width*1) : 0)
+                .animation(
+                    Animation.linear(duration: 6.5)
+                    .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            //흰색 레이어
+            getWave(interval: universalSize.width*1.7, amplitude: 86, baseline: 70 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 1, green: 1, blue: 1).opacity(0.5))
+                .offset(x: isAnimated ? -1*(universalSize.width*1.7) : 0)
+                .animation(
+                    Animation.linear(duration: 11.8)
+                    .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            getWave(interval: universalSize.width*1.2, amplitude: 70, baseline: -200 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 0.1, green: 0.6, blue: 1).opacity(0.1))
+                .offset(x: isAnimated ? -1*(universalSize.width*1.2) : 0)
+                .animation(
+                    Animation.linear(duration: 8.7)
+                    .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            getWave(interval: universalSize.width*1.6, amplitude: 150, baseline: -240 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 0.1, green: 0.6, blue: 1).opacity(0.1))
+                .offset(x: isAnimated ? -1*(universalSize.width*1.6) : 0)
+                .animation(
+                    Animation.linear(duration: 15.7)
+                    .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            //흰색 레이어
+            getWave(interval: universalSize.width*1.2, amplitude: 200, baseline: 150 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 1, green: 1, blue: 1).opacity(0.3))
+                .offset(x: isAnimated ? -1*(universalSize.width*1.2) : 0)
+                .animation(
+                    Animation.linear(duration: 8.7)
+                    .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            getWave(interval: universalSize.width*1.5, amplitude: 120, baseline: 200 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 0.1, green: 0.6, blue: 1).opacity(0.1))
+                .offset(x: isAnimated ? -1*(universalSize.width*1.5) : 0)
+                .animation(
+                    Animation.linear(duration: 18.4)
+                    .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            
+        }
+        
+        .onAppear(){
+            self.isAnimated = true
+        }
+        .blur(radius: 12)
+        
+    }
+    
+    func getWave(interval:CGFloat, amplitude: CGFloat = 100 ,baseline:CGFloat = UIScreen.main.bounds.height/2) -> Path {
+        Path{path in
+            path.move(to: CGPoint(x: 0, y: baseline
+                                 ))
+            path.addCurve(
+                to: CGPoint(x: 1*interval,y: baseline),
+                control1: CGPoint(x: interval * (0.35),y: amplitude + baseline),
+                control2: CGPoint(x: interval * (0.65),y: -amplitude + baseline)
+            )
+            path.addCurve(
+                to: CGPoint(x: 2*interval,y: baseline),
+                control1: CGPoint(x: interval * (1.35),y: amplitude + baseline),
+                control2: CGPoint(x: interval * (1.65),y: -amplitude + baseline)
+            )
+            path.addLine(to: CGPoint(x: 2*interval, y: universalSize.height))
+            path.addLine(to: CGPoint(x: 0, y: universalSize.height))
+            
+            
+        }
+        
+    }
+}
+struct MeasureBackgroundAnimation_Previews: PreviewProvider {
+    static var previews: some View {
+        MeasureBackgroundAnimation()
+    }
+}

--- a/Bingha/Bingha/Views/Home/Measure/MeasureBackgroundAnimation.swift
+++ b/Bingha/Bingha/Views/Home/Measure/MeasureBackgroundAnimation.swift
@@ -90,20 +90,16 @@ struct MeasureBackgroundAnimation: View {
                     .repeatForever(autoreverses: false),
                     value: isAnimated
                 )
-            
         }
-        
         .onAppear(){
             self.isAnimated = true
         }
         .blur(radius: 12)
-        
     }
     
     func getWave(interval:CGFloat, amplitude: CGFloat = 100 ,baseline:CGFloat = UIScreen.main.bounds.height/2) -> Path {
         Path{path in
-            path.move(to: CGPoint(x: 0, y: baseline
-                                 ))
+            path.move(to: CGPoint(x: 0, y: baseline))
             path.addCurve(
                 to: CGPoint(x: 1*interval,y: baseline),
                 control1: CGPoint(x: interval * (0.35),y: amplitude + baseline),
@@ -116,10 +112,7 @@ struct MeasureBackgroundAnimation: View {
             )
             path.addLine(to: CGPoint(x: 2*interval, y: universalSize.height))
             path.addLine(to: CGPoint(x: 0, y: universalSize.height))
-            
-            
-        }
-        
+        } 
     }
 }
 struct MeasureBackgroundAnimation_Previews: PreviewProvider {

--- a/Bingha/Bingha/Views/Iceberg/IcebergBackgroundAnimation.swift
+++ b/Bingha/Bingha/Views/Iceberg/IcebergBackgroundAnimation.swift
@@ -1,0 +1,73 @@
+//
+//  IcebergBackgroundAnimation.swift
+//  Bingha
+//
+//  Created by HanGyeongjun on 2022/07/26.
+//
+
+import SwiftUI
+
+struct IcebergBackgroundAnimation: View {
+    
+    let universalSize = UIScreen.main.bounds
+    
+    @State private var isAnimated = false
+    
+    var body: some View {
+        
+        ZStack {
+            getWave(interval: universalSize.width, amplitude: 80, baseline: -50 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 0.0, green: 0.6, blue: 1).opacity(0.1))
+                .offset(x: isAnimated ? -1*universalSize.width : 0)
+                .animation(
+                    Animation.linear(duration: 19.9)
+                        .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            getWave(interval: universalSize.width*1.5, amplitude: 70, baseline: -50 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 0.1, green: 0.6, blue: 1).opacity(0.1))
+                .offset(x: isAnimated ? -1*(universalSize.width*1.5) : 0)
+                .animation(
+                    Animation.linear(duration: 11.7)
+                        .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+            getWave(interval: universalSize.width*1.8, amplitude: 50, baseline: -50 + universalSize.height/2)
+                .foregroundColor(Color.init(red: 0.4, green: 0.6, blue: 1).opacity(0.1))
+                .offset(x: isAnimated ? -1*(universalSize.width*1.8) : 0)
+                .animation(
+                    Animation.linear(duration: 15.4)
+                        .repeatForever(autoreverses: false),
+                    value: isAnimated
+                )
+        }
+        .onAppear(){
+            self.isAnimated = true
+        }
+    }
+    
+    func getWave(interval:CGFloat, amplitude: CGFloat = 100 ,baseline:CGFloat = UIScreen.main.bounds.height/2) -> Path {
+        Path{path in
+            path.move(to: CGPoint(x: 0, y: baseline
+                                 ))
+            path.addCurve(
+                to: CGPoint(x: 1*interval,y: baseline),
+                control1: CGPoint(x: interval * (0.35),y: amplitude + baseline),
+                control2: CGPoint(x: interval * (0.65),y: -amplitude + baseline)
+            )
+            path.addCurve(
+                to: CGPoint(x: 2*interval,y: baseline),
+                control1: CGPoint(x: interval * (1.35),y: amplitude + baseline),
+                control2: CGPoint(x: interval * (1.65),y: -amplitude + baseline)
+            )
+            path.addLine(to: CGPoint(x: 2*interval, y: universalSize.height))
+            path.addLine(to: CGPoint(x: 0, y: universalSize.height))
+        }
+    }
+}
+
+struct IcebergBackgroundAnimation_Previews: PreviewProvider {
+    static var previews: some View {
+        IcebergBackgroundAnimation()
+    }
+}


### PR DESCRIPTION
## 작업사항

- 빙하 뷰 및 측정 중일 때의 백그라운드 애니메이션은 SwiftUI를 통해 구현했습니다.
- 빙하 뷰에서는 바다 느낌이 나도록 기기 중심에서 50pt 위 지점에서 wave가 생기도록 했습니다.
- 측정 뷰에서는 레퍼런스 애니메이션과 유사하게 화면 전체에 걸쳐 wave와 블러 효과를 적용했습니다.

## 이슈 번호

#59 측정 및 빙하 뷰 백그라운드 애니메이션 구현

## 특이사항 (optional)

아직 두 파일 모두 UIkit 뷰와는 연결되지 않은 상태로 추후 작업이 필요합니다.
