### PR TITLE
[2022.07.30] feat/launchscreen>> 런치스크린 제작

### DIFF
--- a/Bingha/Bingha.xcodeproj/project.pbxproj
+++ b/Bingha/Bingha.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0E3D563B2894F76B007C8805 /* LaunchViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E3D563A2894F76B007C8805 /* LaunchViewController.swift */; };
+		0E3D563D2894F777007C8805 /* Launch.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 0E3D563C2894F777007C8805 /* Launch.storyboard */; };
 		0E8C8E5E2885428300A9ABDB /* DecreaseCarbonModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E8C8E5D2885428300A9ABDB /* DecreaseCarbonModel.swift */; };
 		0EBB5DCB2884523600C42C3B /* FirebaseController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EBB5DCA2884523600C42C3B /* FirebaseController.swift */; };
 		0EE172F52882ED3D00AD5100 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 0EE172F42882ED3D00AD5100 /* FirebaseAnalytics */; };
@@ -49,6 +51,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		0E3D563A2894F76B007C8805 /* LaunchViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LaunchViewController.swift; sourceTree = "<group>"; };
+		0E3D563C2894F777007C8805 /* Launch.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = Launch.storyboard; sourceTree = "<group>"; };
 		0E8C8E5D2885428300A9ABDB /* DecreaseCarbonModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecreaseCarbonModel.swift; sourceTree = "<group>"; };
 		0EBB5DCA2884523600C42C3B /* FirebaseController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseController.swift; sourceTree = "<group>"; };
 		0EE172FA2882EE7F00AD5100 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
@@ -109,6 +113,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0E3D56392894F74B007C8805 /* Launch */ = {
+			isa = PBXGroup;
+			children = (
+				0E3D563A2894F76B007C8805 /* LaunchViewController.swift */,
+				0E3D563C2894F777007C8805 /* Launch.storyboard */,
+			);
+			path = Launch;
+			sourceTree = "<group>";
+		};
 		39D883DB28854654006067C8 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
@@ -179,6 +192,7 @@
 		5516E73A288128CF0015D64A /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				0E3D56392894F74B007C8805 /* Launch */,
 				39E50CDB2887ED7B00173E25 /* TabBar */,
 				5516E741288129380015D64A /* Home */,
 				5516E7422881294A0015D64A /* Stat */,
@@ -348,6 +362,7 @@
 				397706452887EDB300C4F82F /* TabBar.storyboard in Resources */,
 				39F87AE92891260000708744 /* StatisticsCollectionViewCell.xib in Resources */,
 				552549912882B7ED00C0C75A /* Measure.storyboard in Resources */,
+				0E3D563D2894F777007C8805 /* Launch.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -374,6 +389,7 @@
 				5516E729288128B20015D64A /* SceneDelegate.swift in Sources */,
 				39D883DF28854901006067C8 /* FormatterExtension.swift in Sources */,
 				5516E749288129C00015D64A /* MeasureViewController.swift in Sources */,
+				0E3D563B2894F76B007C8805 /* LaunchViewController.swift in Sources */,
 				0E8C8E5E2885428300A9ABDB /* DecreaseCarbonModel.swift in Sources */,
 				39D883DA28853C5F006067C8 /* ReducedCarbonCalculator.swift in Sources */,
 				39F87AE5289121B900708744 /* StatViewController.swift in Sources */,

--- a/Bingha/Bingha/Info.plist
+++ b/Bingha/Bingha/Info.plist
@@ -16,7 +16,7 @@
 					<key>UISceneDelegateClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
 					<key>UISceneStoryboardFile</key>
-					<string>TabBar</string>
+					<string>Launch</string>
 				</dict>
 			</array>
 		</dict>

--- a/Bingha/Bingha/Views/Home/Measure/Measure.storyboard
+++ b/Bingha/Bingha/Views/Home/Measure/Measure.storyboard
@@ -199,7 +199,7 @@
     </scenes>
     <resources>
         <image name="StandingMan" width="640" height="640"/>
-        <image name="house" catalog="system" width="32" height="32"/>
+        <image name="house" catalog="system" width="128" height="106"/>
         <systemColor name="labelColor">
             <color white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
         </systemColor>

--- a/Bingha/Bingha/Views/Home/Measure/MeasureViewController.swift
+++ b/Bingha/Bingha/Views/Home/Measure/MeasureViewController.swift
@@ -64,8 +64,6 @@ class MeasureViewController: UIViewController {
         setNotification()
         setAttribute()
 
-        // 비동기 처리. 파이어베이스에서 오늘 총 탄소 저감량 데이터 불러와서 라벨에 매핑.
-        loadTodayCarbondata()
     }
     
     // 버튼 눌렀을 때 뷰 스위칭
@@ -261,14 +259,6 @@ class MeasureViewController: UIViewController {
     @objc func stopTimerAndSaveSeconds() {
         self.timer?.invalidate()
         UserDefaults.standard.setValue(totalSecond, forKey: "totalSecond")
-    }
-    
-    private func loadTodayCarbondata() {
-        Task {
-            try await firebaseController.loadTodayCarbonData()
-            todayCarbonDecrease = FirebaseController.carbonModel.todayTotalDecreaseCarbon
-            totalReducedCarbonLabel.text = todayCarbonDecrease.setOneDemical() + "g"
-        }
     }
     
     private func saveData() {

--- a/Bingha/Bingha/Views/Launch/Launch.storyboard
+++ b/Bingha/Bingha/Views/Launch/Launch.storyboard
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Launch View Controller-->
+        <scene sceneID="s0d-6b-0kx">
+            <objects>
+                <viewController storyboardIdentifier="LaunchViewController" id="Y6W-OH-hqX" customClass="LaunchViewController" customModule="Bingha" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="DummyTree" translatesAutoresizingMaskIntoConstraints="NO" id="ggq-sJ-Z1Q">
+                                <rect key="frame" x="87" y="318" width="240" height="260"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            </imageView>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="런치스크린" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="15Z-Pu-NYc">
+                                <rect key="frame" x="170" y="196" width="74" height="144"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                <nil key="textColor"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <viewLayoutGuide key="safeArea" id="vDu-zF-Fre"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                        <constraints>
+                            <constraint firstItem="15Z-Pu-NYc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="170" id="UBX-uu-dk6"/>
+                            <constraint firstItem="15Z-Pu-NYc" firstAttribute="centerY" secondItem="5EZ-qb-Rvc" secondAttribute="centerY" constant="-180" id="XR6-m4-bEu"/>
+                            <constraint firstItem="15Z-Pu-NYc" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="152" id="jcu-kn-UJB"/>
+                        </constraints>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="28.985507246376812" y="79.6875"/>
+        </scene>
+    </scenes>
+    <resources>
+        <image name="DummyTree" width="300" height="300"/>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
+</document>

--- a/Bingha/Bingha/Views/Launch/LaunchViewController.swift
+++ b/Bingha/Bingha/Views/Launch/LaunchViewController.swift
@@ -19,6 +19,19 @@ class LaunchViewController: UIViewController {
         // 데이터 로드 로직 넣기.
         // 온보딩을 봤는지 안봤는지 체크하기. 유저디폴트에서 꺼내 확인한다. isFirst만 바꿔주면 됨!
         // 데이터 다 불러와지면 넘기게!
+        Task {
+            try await firebaseController.loadTodayCarbonData()
+        }
+        Task {
+            try await firebaseController.loadIcebergData()
+        }
+        Task {
+            try await firebaseController.loadMonthlyData()
+        }
+        Task {
+            try await firebaseController.loadWeeklyData()
+        }
+        
         DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .seconds(1))) { [weak self] in
             self?.changeView(isFirst: false)
         }
@@ -26,7 +39,7 @@ class LaunchViewController: UIViewController {
     
     func changeView(isFirst: Bool) {
         if isFirst {
-            // 온보딩으로 바꿔줘야함.
+            // TODO: 온보딩 완성되면 연결해주기.
             let st = UIStoryboard(name: "First", bundle: nil)
             let vc = st.instantiateViewController(withIdentifier: "FirstViewController")
             let scenes = UIApplication.shared.connectedScenes

--- a/Bingha/Bingha/Views/Launch/LaunchViewController.swift
+++ b/Bingha/Bingha/Views/Launch/LaunchViewController.swift
@@ -16,9 +16,39 @@ class LaunchViewController: UIViewController {
     }
     
     override func viewDidAppear(_ animated: Bool) {
-        // 데이터 로드 로직 넣기.
+        // 파이어베이스에서 데이터 로드.
+        pullFirebaseData()
         // 온보딩을 봤는지 안봤는지 체크하기. 유저디폴트에서 꺼내 확인한다. isFirst만 바꿔주면 됨!
         // 데이터 다 불러와지면 넘기게!
+        DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .seconds(1))) { [weak self] in
+            self?.changeView(isFirst: false)
+        }
+    }
+    
+    func changeView(isFirst: Bool) {
+        if isFirst {
+            // TODO: 온보딩 완성되면 연결해주기.
+//            let st = UIStoryboard(name: "First", bundle: nil)
+//            let vc = st.instantiateViewController(withIdentifier: "FirstViewController")
+//            let scenes = UIApplication.shared.connectedScenes
+//            let windowScenes = scenes.first as? UIWindowScene
+//            if let window = windowScenes?.windows.first {
+//                window.rootViewController = vc
+//            }
+        }
+        // 깔깔깔 해치웠다.
+        else {
+            let st = UIStoryboard(name: "TabBar", bundle: nil)
+            let vc = st.instantiateViewController(withIdentifier: "TabBar")
+            let scenes = UIApplication.shared.connectedScenes
+            let windowScenes = scenes.first as? UIWindowScene
+            if let window = windowScenes?.windows.first {
+                window.rootViewController = vc
+            }
+        }
+    }
+    
+    func pullFirebaseData() {
         Task {
             try await firebaseController.loadTodayCarbonData()
         }
@@ -30,33 +60,6 @@ class LaunchViewController: UIViewController {
         }
         Task {
             try await firebaseController.loadWeeklyData()
-        }
-        
-        DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .seconds(1))) { [weak self] in
-            self?.changeView(isFirst: false)
-        }
-    }
-    
-    func changeView(isFirst: Bool) {
-        if isFirst {
-            // TODO: 온보딩 완성되면 연결해주기.
-            let st = UIStoryboard(name: "First", bundle: nil)
-            let vc = st.instantiateViewController(withIdentifier: "FirstViewController")
-            let scenes = UIApplication.shared.connectedScenes
-            let windowScenes = scenes.first as? UIWindowScene
-            if let window = windowScenes?.windows.first {
-                window.rootViewController = vc
-            }
-        }
-        // 깔깔깔 해치웠다.
-        else {
-            let st = UIStoryboard(name: "TabBar", bundle: nil)
-            let vc = st.instantiateViewController(withIdentifier: "TabBar")
-            let scenes = UIApplication.shared.connectedScenes
-            let windowScenes = scenes.first as? UIWindowScene
-            if let window = windowScenes?.windows.first {
-                window.rootViewController = vc
-            }
         }
     }
 }

--- a/Bingha/Bingha/Views/Launch/LaunchViewController.swift
+++ b/Bingha/Bingha/Views/Launch/LaunchViewController.swift
@@ -1,0 +1,49 @@
+//
+//  LaunchViewController.swift
+//  Bingha
+//
+//  Created by ryu hyunsun on 2022/07/30.
+//
+
+import UIKit
+
+class LaunchViewController: UIViewController {
+    let firebaseController = FirebaseController()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        // 데이터 로드 로직 넣기.
+        // 온보딩을 봤는지 안봤는지 체크하기. 유저디폴트에서 꺼내 확인한다. isFirst만 바꿔주면 됨!
+        // 데이터 다 불러와지면 넘기게!
+        DispatchQueue.main.asyncAfter(deadline: .now().advanced(by: .seconds(1))) { [weak self] in
+            self?.changeView(isFirst: false)
+        }
+    }
+    
+    func changeView(isFirst: Bool) {
+        if isFirst {
+            // 온보딩으로 바꿔줘야함.
+            let st = UIStoryboard(name: "First", bundle: nil)
+            let vc = st.instantiateViewController(withIdentifier: "FirstViewController")
+            let scenes = UIApplication.shared.connectedScenes
+            let windowScenes = scenes.first as? UIWindowScene
+            if let window = windowScenes?.windows.first {
+                window.rootViewController = vc
+            }
+        }
+        // 깔깔깔 해치웠다.
+        else {
+            let st = UIStoryboard(name: "TabBar", bundle: nil)
+            let vc = st.instantiateViewController(withIdentifier: "TabBar")
+            let scenes = UIApplication.shared.connectedScenes
+            let windowScenes = scenes.first as? UIWindowScene
+            if let window = windowScenes?.windows.first {
+                window.rootViewController = vc
+            }
+        }
+    }
+}


### PR DESCRIPTION
## 작업사항
- 런치스크린 추가.
- 일단 1초 뒤에 넘어가게 만들어 놨음.
- 런치스크린에서 파이어베이스 데이터 불러오는 로직 작성.

## 이슈 번호
- #78 

## 특이사항 (optional)
- 이브가 작업하는 온보딩 화면 완성되면, 유저 디폴트에서 최초 시작인지 받아와서 처리할 수 있게끔 만들어놈.
- 런치스크린 디자인 안함 ㅎㅎ..
- 실행 잘 됨.
