### PR TITLE
[2022.08.01] feat/storyboardLayOut >> 스토리보드 오토레이아웃 재설정

### DIFF
--- a/Bingha/Bingha/Onboarding/Onboarding.storyboard
+++ b/Bingha/Bingha/Onboarding/Onboarding.storyboard
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="20037" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Y6W-OH-hqX">
-    <device id="retina6_1" orientation="portrait" appearance="light"/>
+    <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -14,11 +14,11 @@
             <objects>
                 <viewController storyboardIdentifier="OnboardingViewController" title="OnboardingViewController1" useStoryboardIdentifierAsRestorationIdentifier="YES" id="Y6W-OH-hqX" customClass="OnboardingViewController" customModule="Bingha" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="5EZ-qb-Rvc">
-                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="zyx-6X-GEm">
-                                <rect key="frame" x="318" y="44" width="76" height="32"/>
+                                <rect key="frame" x="294" y="54" width="76" height="32"/>
                                 <color key="tintColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal" title="Button"/>
                                 <buttonConfiguration key="configuration" style="plain" title="건너뛰기">
@@ -29,12 +29,12 @@
                                 </connections>
                             </button>
                             <pageControl opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" numberOfPages="4" translatesAutoresizingMaskIntoConstraints="NO" id="CN9-eu-jnz">
-                                <rect key="frame" x="141" y="806" width="132.5" height="26"/>
+                                <rect key="frame" x="130.33333333333337" y="754" width="129.66666666666663" height="26"/>
                                 <color key="pageIndicatorTintColor" red="0.85098039215686272" green="0.85098039215686272" blue="0.85098039215686272" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <color key="currentPageIndicatorTintColor" red="0.55686274509803924" green="0.55686274509803924" blue="0.57647058823529407" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                             </pageControl>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="weK-dD-aKc">
-                                <rect key="frame" x="30" y="733" width="354" height="63"/>
+                                <rect key="frame" x="30" y="681" width="330" height="63"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="63" id="Hwt-pW-81a"/>
                                     <constraint firstAttribute="height" constant="63" id="TkH-9n-g7b"/>
@@ -60,48 +60,51 @@
                                 </connections>
                             </button>
                             <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" restorationIdentifier="collectionView" bounces="NO" pagingEnabled="YES" showsHorizontalScrollIndicator="NO" showsVerticalScrollIndicator="NO" bouncesZoom="NO" dataMode="prototypes" translatesAutoresizingMaskIntoConstraints="NO" id="EKI-Ox-cuR">
-                                <rect key="frame" x="0.0" y="102" width="414" height="607"/>
+                                <rect key="frame" x="0.0" y="94" width="390" height="563"/>
                                 <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <collectionViewFlowLayout key="collectionViewLayout" scrollDirection="horizontal" minimumLineSpacing="0.0" minimumInteritemSpacing="0.0" id="6Is-cQ-mG5">
-                                    <size key="itemSize" width="417" height="569"/>
+                                    <size key="itemSize" width="392" height="566"/>
                                     <size key="headerReferenceSize" width="0.0" height="0.0"/>
                                     <size key="footerReferenceSize" width="0.0" height="0.0"/>
                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                 </collectionViewFlowLayout>
                                 <cells>
                                     <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="OnboardingCollectionViewCell" id="NTD-3v-xDp" customClass="OnboardingCollectionViewCell" customModule="Bingha" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="19" width="417" height="569"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <rect key="frame" x="0.0" y="-1.6666666666666667" width="392" height="566"/>
+                                        <autoresizingMask key="autoresizingMask"/>
                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="jkt-kz-KTd">
-                                            <rect key="frame" x="0.0" y="0.0" width="417" height="569"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="392" height="566"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="OnboardingEarth" translatesAutoresizingMaskIntoConstraints="NO" id="KgK-U3-gGa">
-                                                    <rect key="frame" x="119" y="90" width="179" height="179"/>
+                                                    <rect key="frame" x="119" y="90" width="154" height="154"/>
                                                     <constraints>
                                                         <constraint firstAttribute="height" relation="lessThanOrEqual" constant="180" id="4Rf-Xp-VHs"/>
                                                         <constraint firstAttribute="width" secondItem="KgK-U3-gGa" secondAttribute="height" multiplier="1:1" id="Jgv-zf-u4n"/>
                                                     </constraints>
                                                 </imageView>
-                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="30" translatesAutoresizingMaskIntoConstraints="NO" id="CGL-1P-syM">
-                                                    <rect key="frame" x="105" y="389" width="207" height="134"/>
+                                                <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="CGL-1P-syM">
+                                                    <rect key="frame" x="92.666666666666671" y="344" width="206.66666666666663" height="209"/>
                                                     <subviews>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="걸어서 지구를 살린다고?" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="5yu-Ys-WHc">
-                                                            <rect key="frame" x="7.5" y="0.0" width="192.5" height="24"/>
+                                                            <rect key="frame" x="7" y="0.0" width="192.66666666666666" height="24"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="24" id="pNx-Z1-RRg"/>
+                                                            </constraints>
                                                             <fontDescription key="fontDescription" type="system" weight="heavy" pointSize="20"/>
                                                             <color key="textColor" red="0.13725490870000001" green="0.72156864399999998" blue="0.81176471709999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tta-Pp-l8l">
-                                                            <rect key="frame" x="0.0" y="54" width="207" height="80"/>
+                                                            <rect key="frame" x="0.0" y="39" width="206.66666666666666" height="170"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="80" id="6as-4a-OZ0"/>
+                                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="6as-4a-OZ0"/>
                                                             </constraints>
                                                             <attributedString key="attributedText">
                                                                 <fragment content="차를">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -116,7 +119,7 @@
                                                                 <fragment content="타는">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -131,7 +134,7 @@
                                                                 <fragment content="대신">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -146,7 +149,7 @@
                                                                 <fragment content="걷는">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -161,7 +164,7 @@
                                                                 <fragment content="것">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -176,7 +179,7 @@
                                                                 <fragment content="만으로도">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -194,7 +197,7 @@ IAo
                                                                 <fragment content="탄소배출을">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -209,7 +212,7 @@ IAo
                                                                 <fragment content="줄여">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -227,7 +230,7 @@ IAo
                                                                 <fragment content="지구의">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="5" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -242,7 +245,7 @@ IAo
                                                                 <fragment content="수명을">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="5" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -257,7 +260,7 @@ IAo
                                                                 <fragment content="늘릴">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="5" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -272,7 +275,7 @@ IAo
                                                                 <fragment content="수">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="5" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -287,7 +290,7 @@ IAo
                                                                 <fragment content="있어요">
                                                                     <attributes>
                                                                         <color key="NSColor" red="0.5568627451" green="0.5568627451" blue="0.57647058819999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                        <font key="NSFont" metaFont="system" size="16"/>
+                                                                        <font key="NSFont" size="16" name=".AppleSDGothicNeoI-Regular"/>
                                                                         <font key="NSOriginalFont" metaFont="system" size="16"/>
                                                                         <paragraphStyle key="NSParagraphStyle" alignment="center" lineBreakMode="wordWrapping" baseWritingDirection="natural" lineSpacing="5" tighteningFactorForTruncation="0.0"/>
                                                                     </attributes>
@@ -303,9 +306,13 @@ IAo
                                                             <nil key="highlightedColor"/>
                                                         </label>
                                                     </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="5yu-Ys-WHc" firstAttribute="centerX" secondItem="CGL-1P-syM" secondAttribute="centerX" id="Wxf-k9-mXz"/>
+                                                        <constraint firstItem="tta-Pp-l8l" firstAttribute="top" secondItem="5yu-Ys-WHc" secondAttribute="bottom" constant="15" id="vZR-MC-8df"/>
+                                                    </constraints>
                                                 </stackView>
                                                 <view alpha="0.14999999999999999" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="YYs-uk-Iq4">
-                                                    <rect key="frame" x="69" y="40" width="279" height="279"/>
+                                                    <rect key="frame" x="69" y="40" width="254" height="254"/>
                                                     <color key="backgroundColor" red="0.13725490870000001" green="0.72156864399999998" blue="0.81176471709999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                                     <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                     <constraints>
@@ -316,17 +323,19 @@ IAo
                                             </subviews>
                                             <constraints>
                                                 <constraint firstAttribute="trailing" secondItem="YYs-uk-Iq4" secondAttribute="trailing" constant="69" id="1vP-i5-4qf"/>
+                                                <constraint firstAttribute="bottomMargin" relation="lessThanOrEqual" secondItem="CGL-1P-syM" secondAttribute="bottom" constant="5" id="4LH-yJ-jNt"/>
                                                 <constraint firstItem="YYs-uk-Iq4" firstAttribute="centerY" secondItem="KgK-U3-gGa" secondAttribute="centerY" id="Fh4-zX-o1f"/>
                                                 <constraint firstItem="CGL-1P-syM" firstAttribute="centerX" secondItem="jkt-kz-KTd" secondAttribute="centerX" id="USv-Rx-p84"/>
                                                 <constraint firstItem="KgK-U3-gGa" firstAttribute="top" secondItem="jkt-kz-KTd" secondAttribute="top" constant="90" id="awq-bc-bXh"/>
-                                                <constraint firstItem="CGL-1P-syM" firstAttribute="top" secondItem="KgK-U3-gGa" secondAttribute="bottom" constant="120" id="b5j-Lz-422"/>
+                                                <constraint firstItem="CGL-1P-syM" firstAttribute="top" relation="lessThanOrEqual" secondItem="KgK-U3-gGa" secondAttribute="bottom" constant="100" id="b5j-Lz-422"/>
                                                 <constraint firstItem="YYs-uk-Iq4" firstAttribute="top" secondItem="jkt-kz-KTd" secondAttribute="top" constant="40" id="cdr-vW-wsb"/>
+                                                <constraint firstItem="CGL-1P-syM" firstAttribute="top" secondItem="YYs-uk-Iq4" secondAttribute="bottom" constant="50" id="det-tR-lU8"/>
                                                 <constraint firstItem="KgK-U3-gGa" firstAttribute="centerX" secondItem="YYs-uk-Iq4" secondAttribute="centerX" id="guD-aI-Ahb"/>
                                                 <constraint firstItem="KgK-U3-gGa" firstAttribute="centerX" secondItem="jkt-kz-KTd" secondAttribute="centerX" id="iaA-FO-cls"/>
                                                 <constraint firstItem="KgK-U3-gGa" firstAttribute="top" secondItem="jkt-kz-KTd" secondAttribute="top" constant="90" id="xVt-M5-pCm"/>
                                             </constraints>
                                         </collectionViewCellContentView>
-                                        <size key="customSize" width="417" height="569"/>
+                                        <size key="customSize" width="392" height="566"/>
                                         <connections>
                                             <outlet property="backgroundCircle" destination="YYs-uk-Iq4" id="vHU-1U-hXK"/>
                                             <outlet property="collectionView" destination="jkt-kz-KTd" id="kgS-gN-dZ5"/>
@@ -354,9 +363,9 @@ IAo
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="CN9-eu-jnz" secondAttribute="bottom" constant="30" id="PJY-Ff-9OE"/>
                             <constraint firstItem="CN9-eu-jnz" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="atI-T9-u7r"/>
                             <constraint firstItem="EKI-Ox-cuR" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" id="g2S-s7-rYC"/>
-                            <constraint firstItem="EKI-Ox-cuR" firstAttribute="top" secondItem="zyx-6X-GEm" secondAttribute="bottom" constant="26" id="i17-sH-9q7"/>
+                            <constraint firstItem="EKI-Ox-cuR" firstAttribute="top" secondItem="zyx-6X-GEm" secondAttribute="bottom" constant="8" id="i17-sH-9q7"/>
                             <constraint firstItem="weK-dD-aKc" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="30" id="sQ0-qr-wYE"/>
-                            <constraint firstItem="zyx-6X-GEm" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" id="yRs-sX-cFF"/>
+                            <constraint firstItem="zyx-6X-GEm" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="10" id="yRs-sX-cFF"/>
                         </constraints>
                     </view>
                     <connections>
@@ -368,7 +377,7 @@ IAo
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="60.869565217391312" y="106.47321428571428"/>
+            <point key="canvasLocation" x="60" y="105.92417061611374"/>
         </scene>
     </scenes>
     <resources>

--- a/Bingha/Bingha/Onboarding/RequestAccessView.storyboard
+++ b/Bingha/Bingha/Onboarding/RequestAccessView.storyboard
@@ -17,7 +17,7 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="15" translatesAutoresizingMaskIntoConstraints="NO" id="FLD-au-SlE" userLabel="TopStackView">
-                                <rect key="frame" x="104.5" y="184" width="205" height="125.5"/>
+                                <rect key="frame" x="104.5" y="144" width="205" height="125.5"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" usesAttributedText="YES" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="IkY-5z-IjP">
                                         <rect key="frame" x="12" y="0.0" width="181.5" height="69.5"/>
@@ -179,7 +179,7 @@
                                 </connections>
                             </button>
                             <stackView opaque="NO" userInteractionEnabled="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="22" translatesAutoresizingMaskIntoConstraints="NO" id="NWk-sO-ab4" userLabel="MiddleStackView">
-                                <rect key="frame" x="50" y="389.5" width="314" height="96"/>
+                                <rect key="frame" x="50" y="349.5" width="314" height="96"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="yvf-Do-LeY">
                                         <rect key="frame" x="0.0" y="0.0" width="314" height="1"/>
@@ -276,7 +276,7 @@
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="jvK-Mx-kcg" secondAttribute="trailing" constant="30" id="Hn8-xB-5vH"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="jvK-Mx-kcg" secondAttribute="bottom" constant="66" id="WX5-hM-ylP"/>
                             <constraint firstItem="FLD-au-SlE" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="ahe-id-HsN"/>
-                            <constraint firstItem="FLD-au-SlE" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="140" id="gyT-LA-dIu"/>
+                            <constraint firstItem="FLD-au-SlE" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="100" id="gyT-LA-dIu"/>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="NWk-sO-ab4" secondAttribute="trailing" constant="50" id="jRE-Fj-zRE"/>
                         </constraints>
                     </view>

--- a/Bingha/Bingha/Onboarding/RequestAccessViewController.swift
+++ b/Bingha/Bingha/Onboarding/RequestAccessViewController.swift
@@ -12,7 +12,7 @@ class RequestAccessViewController: UIViewController {
     @IBOutlet weak var backgroundCircle: UIView!
     @IBOutlet weak var startButton: UIButton!
     @IBAction func startButtonTapped(_ sender: Any) {
-        SkipToMainVC()
+        skipToMainVC()
     }
     
     override func viewDidLoad() {
@@ -27,7 +27,7 @@ class RequestAccessViewController: UIViewController {
         startButton.titleLabel?.font = UIFont.systemFont(ofSize: 22.0, weight: .bold)
     }
     
-    private func SkipToMainVC() {
+    private func skipToMainVC() {
         // 유저디폴트에 저장하기.
         let defaults = UserDefaults.standard
         if defaults.object(forKey: "isFirst") != nil {

--- a/Bingha/Bingha/Views/Home/Measure/Measure.storyboard
+++ b/Bingha/Bingha/Views/Home/Measure/Measure.storyboard
@@ -16,17 +16,20 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="uFN-Ka-maw" userLabel="오늘 총 탄소배출 저감량">
-                                <rect key="frame" x="112.5" y="134" width="189" height="90"/>
+                            <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="uFN-Ka-maw" userLabel="오늘 총 탄소배출 저감량">
+                                <rect key="frame" x="112.5" y="114" width="189" height="131"/>
                                 <subviews>
-                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="오늘 총 탄소배출 저감량" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gsx-7y-2g1" userLabel="오늘 총 탄소배출 저감량">
-                                        <rect key="frame" x="0.0" y="0.0" width="189" height="24"/>
+                                    <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="252" text="오늘 총 탄소배출 저감량" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Gsx-7y-2g1" userLabel="오늘 총 탄소배출 저감량">
+                                        <rect key="frame" x="0.0" y="0.0" width="189" height="71"/>
                                         <fontDescription key="fontDescription" name="AppleSDGothicNeo-Medium" family="Apple SD Gothic Neo" pointSize="20"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="0.0g" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MYQ-if-AEg">
-                                        <rect key="frame" x="43.5" y="34" width="102.5" height="56"/>
+                                        <rect key="frame" x="43.5" y="71" width="102.5" height="60"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="60" id="Xz7-op-Ks2"/>
+                                        </constraints>
                                         <fontDescription key="fontDescription" name="ArialRoundedMTBold" family="Arial Rounded MT Bold" pointSize="48"/>
                                         <color key="textColor" red="0.13725490870000001" green="0.72156864399999998" blue="0.81176471709999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                         <nil key="highlightedColor"/>
@@ -34,7 +37,7 @@
                                 </subviews>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="0Tz-xb-ZMl" userLabel="이동 시간 &amp; 선">
-                                <rect key="frame" x="72" y="331" width="270" height="99"/>
+                                <rect key="frame" x="72" y="352" width="270" height="99"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="5Of-jw-Kgn">
                                         <rect key="frame" x="106" y="0.0" width="58" height="58"/>
@@ -48,6 +51,7 @@
                                             </imageView>
                                         </subviews>
                                         <constraints>
+                                            <constraint firstItem="a8q-Nr-2Sz" firstAttribute="top" secondItem="5Of-jw-Kgn" secondAttribute="top" constant="5" id="9KP-rl-QtT"/>
                                             <constraint firstItem="a8q-Nr-2Sz" firstAttribute="centerX" secondItem="5Of-jw-Kgn" secondAttribute="centerX" id="B0h-ml-jKE"/>
                                             <constraint firstItem="a8q-Nr-2Sz" firstAttribute="centerY" secondItem="5Of-jw-Kgn" secondAttribute="centerY" constant="5" id="rue-uI-zW8"/>
                                             <constraint firstItem="a8q-Nr-2Sz" firstAttribute="leading" secondItem="5Of-jw-Kgn" secondAttribute="leading" id="vZa-f1-SYD"/>
@@ -71,12 +75,9 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="0Tz-xb-ZMl" secondAttribute="height" multiplier="30:11" id="Kuv-p7-Ctw"/>
-                                </constraints>
                             </stackView>
                             <stackView opaque="NO" contentMode="scaleToFill" distribution="fillEqually" spacing="14" translatesAutoresizingMaskIntoConstraints="NO" id="HWe-Eq-FzX" userLabel="이동거리 &amp; 탄소배출 저감량">
-                                <rect key="frame" x="16" y="470" width="382" height="107"/>
+                                <rect key="frame" x="16" y="506" width="382" height="107"/>
                                 <subviews>
                                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="4Lk-6i-nUT" userLabel="이동거리 뷰">
                                         <rect key="frame" x="0.0" y="0.0" width="184" height="107"/>
@@ -139,11 +140,11 @@
                                 </subviews>
                             </stackView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Qal-4G-7ez">
-                                <rect key="frame" x="134" y="617" width="146" height="146"/>
+                                <rect key="frame" x="137" y="643" width="140" height="140"/>
                                 <color key="backgroundColor" red="0.13725490870000001" green="0.72156864399999998" blue="0.81176471709999998" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Qal-4G-7ez" secondAttribute="height" multiplier="1:1" id="Oyf-Zy-vMR"/>
-                                    <constraint firstAttribute="width" constant="146" id="uIm-D6-v0d"/>
+                                    <constraint firstAttribute="width" constant="140" id="uIm-D6-v0d"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name=".AppleSDGothicNeoI-Regular" family=".Apple SD Gothic NeoI" pointSize="32"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
@@ -159,15 +160,21 @@
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" secondItem="HWe-Eq-FzX" secondAttribute="trailing" constant="16" id="08f-Bq-B03"/>
-                            <constraint firstItem="0Tz-xb-ZMl" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="Dwq-WH-n4Q"/>
-                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="Qal-4G-7ez" secondAttribute="bottom" constant="50" id="J5V-fY-T2t"/>
-                            <constraint firstItem="Qal-4G-7ez" firstAttribute="top" secondItem="HWe-Eq-FzX" secondAttribute="bottom" constant="40" id="SHa-bm-52Z"/>
-                            <constraint firstItem="uFN-Ka-maw" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="90" id="XXS-nl-BA4"/>
-                            <constraint firstItem="HWe-Eq-FzX" firstAttribute="top" secondItem="0Tz-xb-ZMl" secondAttribute="bottom" constant="40" id="a0Z-6Z-EiU"/>
+                            <constraint firstItem="HWe-Eq-FzX" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="6uo-PH-wTE"/>
+                            <constraint firstItem="0Tz-xb-ZMl" firstAttribute="centerX" relation="greaterThanOrEqual" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="Dwq-WH-n4Q"/>
+                            <constraint firstItem="HWe-Eq-FzX" firstAttribute="top" relation="lessThanOrEqual" secondItem="0Tz-xb-ZMl" secondAttribute="bottom" constant="55" id="Lij-d7-Vsz"/>
+                            <constraint firstItem="Qal-4G-7ez" firstAttribute="top" relation="greaterThanOrEqual" secondItem="HWe-Eq-FzX" secondAttribute="bottom" constant="30" id="SHa-bm-52Z"/>
+                            <constraint firstItem="uFN-Ka-maw" firstAttribute="top" secondItem="vDu-zF-Fre" secondAttribute="top" constant="70" id="XXS-nl-BA4"/>
+                            <constraint firstItem="0Tz-xb-ZMl" firstAttribute="top" relation="lessThanOrEqual" secondItem="uFN-Ka-maw" secondAttribute="bottom" constant="107" id="avv-NP-EyZ"/>
                             <constraint firstItem="HWe-Eq-FzX" firstAttribute="leading" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="16" id="dbF-CU-E9Q"/>
+                            <constraint firstItem="Qal-4G-7ez" firstAttribute="top" secondItem="HWe-Eq-FzX" secondAttribute="bottom" constant="30" id="fVZ-aM-eZz"/>
                             <constraint firstItem="Qal-4G-7ez" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="j7S-qY-zNg"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="bottom" secondItem="Qal-4G-7ez" secondAttribute="bottom" constant="30" id="mdx-PY-AU8"/>
+                            <constraint firstItem="0Tz-xb-ZMl" firstAttribute="leading" relation="lessThanOrEqual" secondItem="vDu-zF-Fre" secondAttribute="leading" constant="72" id="qDP-JW-Cth"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="0Tz-xb-ZMl" secondAttribute="trailing" constant="72" id="qZg-pH-5Fr"/>
                             <constraint firstItem="uFN-Ka-maw" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="rQZ-BL-dD3"/>
                             <constraint firstItem="HWe-Eq-FzX" firstAttribute="centerX" secondItem="5EZ-qb-Rvc" secondAttribute="centerX" id="xcr-bA-xsz"/>
+                            <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="HWe-Eq-FzX" secondAttribute="trailing" constant="16" id="xh5-ZV-muT"/>
                         </constraints>
                     </view>
                     <tabBarItem key="tabBarItem" title="Measure" image="house" catalog="system" id="N3M-5k-kCM"/>

--- a/Bingha/Bingha/Views/Home/Measure/MeasureViewController.swift
+++ b/Bingha/Bingha/Views/Home/Measure/MeasureViewController.swift
@@ -171,7 +171,14 @@ class MeasureViewController: UIViewController {
         startButton.layer.shadowOpacity = 0.2
         startButton.layer.shadowOffset = CGSize(width: 0, height: 2)
         startButton.layer.shadowColor = UIColor.darkGray.cgColor
-        startButton.titleLabel?.font = UIFont.systemFont(ofSize: 32.0, weight: .bold)
+        startButton.titleLabel?.font = UIFont.rounded(ofSize: 32, weight: .bold)
+        
+        //글꼴 설정
+        walkingDistanceLabel.font = .rounded(ofSize: 36, weight: .bold)
+        totalReducedCarbonLabel.font = .rounded(ofSize: 48, weight: .bold)
+        reducedCarbonLabel.font = .rounded(ofSize: 36, weight: .bold)
+        timerLabel.font = .rounded(ofSize: 15, weight: .medium)
+        
     }
     
     private func requestAuthorization() {


### PR DESCRIPTION
## 작업사항

- 온보딩뷰, 권한설정뷰, 홈뷰 스토리보드 오토레이아웃 안깨지게 재설정 했습니다.
- 함수명 lowerCarmelCase로 변경했습니다.

## 이슈 번호

#95


## 특이사항 (optional)



