### PR TITLE
[2022.08.02] feat/statviewFix >> 통계 화면 비교 부분 데이터 연결로직 수정, 탭바 한글 수정, 다크모드 수정

### DIFF
--- a/Bingha/Bingha/Model/CompareModel.swift
+++ b/Bingha/Bingha/Model/CompareModel.swift
@@ -9,6 +9,6 @@ import Foundation
 
 struct Compare {
     let compareImage: String
-    let compareAmount: String
+    var compareAmount: String
     let compareDescription: String
 }

--- a/Bingha/Bingha/Views/CompareViewModel.swift
+++ b/Bingha/Bingha/Views/CompareViewModel.swift
@@ -8,20 +8,20 @@
 import Foundation
 
 class CompareViewModel {
+    public static var compareList: [Compare] = [Compare(compareImage: "PineTree", compareAmount: "0", compareDescription: "소나무 한 그루가\n이 정도의 탄소를\n산소로 바꾸는 데 걸리는 시간"), Compare(compareImage: "Earth", compareAmount: "1", compareDescription: "이만큼의 김이\n흡수한 탄소의 양"), Compare(compareImage: "Oil", compareAmount: "2", compareDescription: "당신의 지킨 빙하의 양")]
+//    init(distance: Double){
+//        compareList.append(Compare(compareImage: "PineTree", compareAmount: ReducedCarbonCalculator.shared.reducedCarbonToTreeForStat(km: distance), compareDescription: "소나무 한 그루가\n이 정도의 탄소를\n산소로 바꾸는 데 걸리는 시간"))
+//        compareList.append(Compare(compareImage: "Earth", compareAmount: ReducedCarbonCalculator.shared.reducedCarbonToSeaweed(km: distance), compareDescription: "이만큼의 김이\n흡수한 탄소의 양"))
+//        compareList.append(Compare(compareImage: "Oil", compareAmount: ReducedCarbonCalculator.shared.protectedGlacier(km: distance), compareDescription: "당신의 지킨 빙하의 양"))
+//    }
+//
     
-    init(distance: Double){
-        compareList.append(Compare(compareImage: "PineTree", compareAmount: ReducedCarbonCalculator.shared.reducedCarbonToTreeForStat(km: distance), compareDescription: "소나무 한 그루가\n이 정도의 탄소를\n산소로 바꾸는 데 걸리는 시간"))
-        compareList.append(Compare(compareImage: "Earth", compareAmount: ReducedCarbonCalculator.shared.reducedCarbonToSeaweed(km: distance), compareDescription: "이만큼의 김이\n흡수한 탄소의 양"))
-        compareList.append(Compare(compareImage: "Oil", compareAmount: ReducedCarbonCalculator.shared.protectedGlacier(km: distance), compareDescription: "당신의 지킨 빙하의 양"))
-    }
-    
-    var compareList: [Compare] = []
     
     var countOfCompareList: Int {
-        return compareList.count
+        return CompareViewModel.compareList.count
     }
     
     func CompareModelInfo(at index: Int) -> Compare {
-        return compareList[index]
+        return CompareViewModel.compareList[index]
     }
 }

--- a/Bingha/Bingha/Views/Home/Measure/Measure.storyboard
+++ b/Bingha/Bingha/Views/Home/Measure/Measure.storyboard
@@ -8,7 +8,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Measure-->
+        <!--측정-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
                 <viewController restorationIdentifier="Measure" storyboardIdentifier="Measure" id="Y6W-OH-hqX" customClass="MeasureViewController" customModule="Bingha" customModuleProvider="target" sceneMemberID="viewController">
@@ -177,7 +177,7 @@
                             <constraint firstItem="vDu-zF-Fre" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="HWe-Eq-FzX" secondAttribute="trailing" constant="16" id="xh5-ZV-muT"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Measure" image="TabBarHome" id="N3M-5k-kCM"/>
+                    <tabBarItem key="tabBarItem" title="측정" image="TabBarHome" id="N3M-5k-kCM"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="imageView" destination="5Of-jw-Kgn" id="MOZ-iV-ffc"/>

--- a/Bingha/Bingha/Views/Iceberg/Iceberg.storyboard
+++ b/Bingha/Bingha/Views/Iceberg/Iceberg.storyboard
@@ -36,7 +36,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                 <color key="tintColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstItem="glF-sr-JQj" firstAttribute="top" secondItem="aIv-UI-e5q" secondAttribute="bottom" constant="10" id="2Es-cs-PfA"/>

--- a/Bingha/Bingha/Views/Iceberg/Iceberg.storyboard
+++ b/Bingha/Bingha/Views/Iceberg/Iceberg.storyboard
@@ -8,7 +8,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Iceberg-->
+        <!--빙하-->
         <scene sceneID="s0d-6b-0kx">
             <objects>
                 <viewController storyboardIdentifier="Iceberg" id="Y6W-OH-hqX" customClass="IcebergViewController" customModule="Bingha" customModuleProvider="target" sceneMemberID="viewController">
@@ -71,7 +71,7 @@
                             <constraint firstItem="uTq-6M-TDR" firstAttribute="top" secondItem="5EZ-qb-Rvc" secondAttribute="top" constant="77" id="lYC-u8-npG"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Iceberg" image="TabBarBingha" id="ox0-hc-D7E"/>
+                    <tabBarItem key="tabBarItem" title="빙하" image="TabBarBingha" id="ox0-hc-D7E"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="informationLabel" destination="aIv-UI-e5q" id="07f-us-oai"/>

--- a/Bingha/Bingha/Views/Iceberg/IcebergViewController.swift
+++ b/Bingha/Bingha/Views/Iceberg/IcebergViewController.swift
@@ -61,12 +61,12 @@ class IcebergViewController: UIViewController {
     private func setLevelLabel(level: String) {
         levelLabel.text = "Lv. \(level)"
         levelLabel.font = .rounded(ofSize: 20, weight: .bold)
+        levelLabel.textColor = UIColor(named: "Primary")
     }
     
     private func setReducedCarbonLabel(distance: Double) {
         reducedCarbonLabel.text = reducedCarbonCalculator.reducedCarbon(km: distance)
         reducedCarbonLabel.font = .rounded(ofSize: 48, weight: .bold)
-        
     }
     
     private func setInformationLabel() {

--- a/Bingha/Bingha/Views/Stat/Stat.storyboard
+++ b/Bingha/Bingha/Views/Stat/Stat.storyboard
@@ -153,7 +153,7 @@
                             <constraint firstItem="Sx5-c0-VaD" firstAttribute="trailing" secondItem="vDu-zF-Fre" secondAttribute="trailing" id="wCX-1x-Wef"/>
                         </constraints>
                     </view>
-                    <tabBarItem key="tabBarItem" title="Chart" image="TabBarChart" id="i6Q-H2-oOw"/>
+                    <tabBarItem key="tabBarItem" title="통계" image="TabBarChart" id="i6Q-H2-oOw"/>
                     <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
                     <connections>
                         <outlet property="collectionView" destination="Sx5-c0-VaD" id="XaZ-vh-3If"/>

--- a/Bingha/Bingha/Views/Stat/StatViewController.swift
+++ b/Bingha/Bingha/Views/Stat/StatViewController.swift
@@ -20,10 +20,7 @@ class StatViewController: UIViewController {
     
     //FIX: 추가됨
     let reducedCarbonCollectionViewModel: ReducedCarbonCollectionViewModel = ReducedCarbonCollectionViewModel()
-    // TODO: - 비교 데이터 넣어줄 부분
-    let todayCompareViewModel: CompareViewModel = CompareViewModel(distance: FirebaseController.todayTotalDecreaseCarbon)
-    let weekCompareViewModel: CompareViewModel = CompareViewModel(distance: FirebaseController.weeklyTotalDecreaseCarbon)
-    let monthCompareViewModel: CompareViewModel = CompareViewModel(distance: FirebaseController.monthlyTotalDecreaseCarbon)
+    let compareViewModel: CompareViewModel = CompareViewModel()
     let statisticsViewModel: StatisticsViewModel = StatisticsViewModel()
     
     let segmentID: String = "CollectionViewSegmentControl"
@@ -38,19 +35,15 @@ class StatViewController: UIViewController {
     var selectedSegment = 0
     // 여기서 컨트롤 하면 될듯.statisticsViewModel에 들어갈 값 변경해주고, compareViewModel 들어갈 값만 변경해주면 끝. 굳굳.
     @IBAction func switchSegment(_ sender: UISegmentedControl) {
-        // 세그먼트 변할 때 마다 데이터 매핑시켜주기. 개꿀!
+        // 세그먼트 변할 때 마다 데이터 매핑시켜주기.
         segmentSetData(sender: sender)
-        
-        // 바로 반영되게 하기 위해선 리로드 데이터 한번 갈겨줘야함.
         collectionView.reloadData()
-        print(sender.selectedSegmentIndex)
     }
     
     
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        //FIX: 추가됨
         collectionView.register(UINib(nibName: "ReducedCarbonCollectionView", bundle: nil), forCellWithReuseIdentifier: reducedID)
         collectionView.register(UINib(nibName: "CompareCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: compareID)
         collectionView.register(UINib(nibName: "StatisticsCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: statisticsID)
@@ -60,8 +53,7 @@ class StatViewController: UIViewController {
         super.viewWillAppear(animated)
         // 이 탭에 들어올때 한번 최신화 시켜줘야함
         segmentloadData()
-        
-        //FIX: 추가됨
+
         collectionView.register(UINib(nibName: "ReducedCarbonCollectionView", bundle: nil), forCellWithReuseIdentifier: reducedID)
         collectionView.register(UINib(nibName: "CompareCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: compareID)
         collectionView.register(UINib(nibName: "StatisticsCollectionViewCell", bundle: nil), forCellWithReuseIdentifier: statisticsID)
@@ -71,33 +63,52 @@ class StatViewController: UIViewController {
     func segmentSetData(sender: UISegmentedControl) {
         if sender.selectedSegmentIndex == 0 {
             StatisticsViewModel.statisticsList = StatisticsViewModel.todayStatisticsList
+            CompareViewModel.compareList[0].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToTreeForStat(km: FirebaseController.todayTotalDecreaseCarbon)
+            CompareViewModel.compareList[1].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToSeaweed(km: FirebaseController.todayTotalDecreaseCarbon)
+            CompareViewModel.compareList[2].compareAmount = ReducedCarbonCalculator.shared.protectedGlacier(km: FirebaseController.todayTotalDecreaseCarbon)
             ReducedCarbonCollectionViewModel.reducedCarbonList[0] = ReducedCarbonCollection(reducedCarbonPeriod: "오늘 총 탄소배출 저감량", reducedCarbonAmount: FirebaseController.todayTotalDecreaseCarbon)
             selectedSegment = 0
         }
         else if sender.selectedSegmentIndex == 1 {
             StatisticsViewModel.statisticsList = StatisticsViewModel.weeklyStatisticsList
+            CompareViewModel.compareList[0].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToTreeForStat(km: FirebaseController.weeklyTotalDecreaseCarbon)
+            CompareViewModel.compareList[1].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToSeaweed(km: FirebaseController.weeklyTotalDecreaseCarbon)
+            CompareViewModel.compareList[2].compareAmount = ReducedCarbonCalculator.shared.protectedGlacier(km: FirebaseController.weeklyTotalDecreaseCarbon)
             ReducedCarbonCollectionViewModel.reducedCarbonList[0] = ReducedCarbonCollection(reducedCarbonPeriod: "최근 3주 간 총 탄소배출 저감량", reducedCarbonAmount: FirebaseController.weeklyTotalDecreaseCarbon)
             selectedSegment = 1
         }
         else {
             StatisticsViewModel.statisticsList = StatisticsViewModel.monthlyStatisticsList
+            CompareViewModel.compareList[0].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToTreeForStat(km: FirebaseController.monthlyTotalDecreaseCarbon)
+            CompareViewModel.compareList[1].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToSeaweed(km: FirebaseController.monthlyTotalDecreaseCarbon)
+            CompareViewModel.compareList[2].compareAmount = ReducedCarbonCalculator.shared.protectedGlacier(km: FirebaseController.monthlyTotalDecreaseCarbon)
             ReducedCarbonCollectionViewModel.reducedCarbonList[0] = ReducedCarbonCollection(reducedCarbonPeriod: "최근 3달 간 총 탄소배출 저감량", reducedCarbonAmount: FirebaseController.monthlyTotalDecreaseCarbon)
             selectedSegment = 2
         }
     }
     
     func segmentloadData() {
+        // 여기 넣는 로직 작성.
         if selectedSegment == 0 {
             StatisticsViewModel.statisticsList = StatisticsViewModel.todayStatisticsList
+            CompareViewModel.compareList[0].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToTreeForStat(km: FirebaseController.todayTotalDecreaseCarbon)
+            CompareViewModel.compareList[1].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToSeaweed(km: FirebaseController.todayTotalDecreaseCarbon)
+            CompareViewModel.compareList[2].compareAmount = ReducedCarbonCalculator.shared.protectedGlacier(km: FirebaseController.todayTotalDecreaseCarbon)
             ReducedCarbonCollectionViewModel.reducedCarbonList[0] = ReducedCarbonCollection(reducedCarbonPeriod: "오늘 총 탄소배출 저감량", reducedCarbonAmount: FirebaseController.todayTotalDecreaseCarbon)
             
         }
         else if selectedSegment == 1 {
             StatisticsViewModel.statisticsList = StatisticsViewModel.weeklyStatisticsList
+            CompareViewModel.compareList[0].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToTreeForStat(km: FirebaseController.weeklyTotalDecreaseCarbon)
+            CompareViewModel.compareList[1].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToSeaweed(km: FirebaseController.weeklyTotalDecreaseCarbon)
+            CompareViewModel.compareList[2].compareAmount = ReducedCarbonCalculator.shared.protectedGlacier(km: FirebaseController.weeklyTotalDecreaseCarbon)
             ReducedCarbonCollectionViewModel.reducedCarbonList[0] = ReducedCarbonCollection(reducedCarbonPeriod: "최근 3주 간 총 탄소배출 저감량", reducedCarbonAmount: FirebaseController.weeklyTotalDecreaseCarbon)
         }
         else {
             StatisticsViewModel.statisticsList = StatisticsViewModel.monthlyStatisticsList
+            CompareViewModel.compareList[0].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToTreeForStat(km: FirebaseController.monthlyTotalDecreaseCarbon)
+            CompareViewModel.compareList[1].compareAmount = ReducedCarbonCalculator.shared.reducedCarbonToSeaweed(km: FirebaseController.monthlyTotalDecreaseCarbon)
+            CompareViewModel.compareList[2].compareAmount = ReducedCarbonCalculator.shared.protectedGlacier(km: FirebaseController.monthlyTotalDecreaseCarbon)
             ReducedCarbonCollectionViewModel.reducedCarbonList[0] = ReducedCarbonCollection(reducedCarbonPeriod: "최근 3달 간 총 탄소배출 저감량", reducedCarbonAmount: FirebaseController.monthlyTotalDecreaseCarbon)
         }
     }

--- a/Bingha/Bingha/Views/StatisticsViewModel.swift
+++ b/Bingha/Bingha/Views/StatisticsViewModel.swift
@@ -8,18 +8,10 @@
 import Foundation
 
 class StatisticsViewModel {
-    public static var statisticsList: [Statistics] = [
-//        Statistics(reducedCarbon: "10kg", walkingDistance: "5km", walkingTime: "1시간", baseDate: "오늘"),
-//        Statistics(reducedCarbon: "20kg", walkingDistance: "7km", walkingTime: "2시간", baseDate: "오늘"),
-//        Statistics(reducedCarbon: "30kg", walkingDistance: "44km", walkingTime: "1시간", baseDate: "오늘"),
-//        Statistics(reducedCarbon: "40kg", walkingDistance: "2km", walkingTime: "5시간", baseDate: "오늘"),
-    ]
-    
+    public static var statisticsList: [Statistics] = []
     public static var todayStatisticsList: [Statistics] = []
     public static var weeklyStatisticsList: [Statistics] = []
     public static var monthlyStatisticsList: [Statistics] = []
-    
-    
     
     var countOfStatisticsList: Int {
         return StatisticsViewModel.statisticsList.count


### PR DESCRIPTION
## 작업사항
- 통계 화면에서 탄소배출 저감량으로 비교하는 부분 연결 로직 수정함.
- 빙하 뷰에서 다크모드일때 레벨, 저감량 안보이는 부분 수정.
- 탭바 영어로 되어 있던 것 한글로 수정
## 이슈 번호
- #117 
- #120 
- #122 

## 특이사항 (optional)
- 코드가 더럽습니다. 양해부탁드립니다.