### PR TITLE
[2022.08.03] fix/timerLabel >> 측정뷰 타이머 60분 넘어가면 60분 안보이던 오류 수정

### DIFF
--- a/Bingha/Bingha/Views/Home/Measure/MeasureViewController.swift
+++ b/Bingha/Bingha/Views/Home/Measure/MeasureViewController.swift
@@ -69,8 +69,8 @@ class MeasureViewController: UIViewController {
                 totalDistance += walkingDistance
                 setDefaultView()
                 
-                let minutes = (totalSecond % 3600) / 60
-                let seconds = (totalSecond % 3600) % 60
+                let minutes = totalSecond / 60
+                let seconds = totalSecond % 60
 
                 guard let nextVC = self.storyboard?.instantiateViewController(identifier: "CompleteReference") as? CompleteViewController else { return }
                 
@@ -211,8 +211,8 @@ class MeasureViewController: UIViewController {
                 self.totalSecond += 1
                 
                 // 타이머표시 Label에서 사용할 변수
-                let minutes = (self.totalSecond % 3600) / 60
-                let seconds = (self.totalSecond % 3600) % 60
+                let minutes = self.totalSecond / 60
+                let seconds = self.totalSecond % 60
                 
                 self.timerLabel.text = String(format: "%d:%02d", minutes, seconds)
             }


### PR DESCRIPTION
## 작업사항
1. 측정뷰 타이머가 60분이 넘어가면 60분이 빠지고 카운트되던 오류 수정
2. 완료뷰로 넘길때 60분을 빼고 넘겨주던 오류 수정

## 이슈 번호

- #130 


## 특이사항
View에 보이는 로직만 수정하였습니다. 데이터 저장에는 문제 없었습니다.